### PR TITLE
Fix crash on attempt to get info on microfactory power source

### DIFF
--- a/mods/saturn/localisation_and_units.lua
+++ b/mods/saturn/localisation_and_units.lua
@@ -15,6 +15,8 @@ saturn.localisation_and_units = {
 	on_place = {hidden = true},
 	on_construct = {hidden = true},
 	on_punch = {hidden = true},
+	on_net_form = {hidden = true},
+	on_net_power_change = {hidden = true},
 	groups = {hidden = true},
 	after_place_node = {hidden = true},
 	on_destruct = {hidden = true},


### PR DESCRIPTION
This is caused by the "localisation_and_units" missing
entries for the two special events the power source
needs. Adding them fixes the problem.