### PR TITLE
Make the station form big and stable

### DIFF
--- a/mods/saturn/gui.lua
+++ b/mods/saturn/gui.lua
@@ -164,7 +164,7 @@ saturn.get_main_inventory_formspec = function(player, vertical_offset)
         if hold_size > 0 then
 	    default_formspec = default_formspec .. "list[current_player;hold;0,"..vertical_offset..";12,4;]"
 	    for iy = 0, 3 do
-	        for ix = 0, 12 do
+	        for ix = 0, 11 do
 			if ix+12*iy >= hold_size then
 			    return default_formspec
 			end

--- a/mods/saturn/items.lua
+++ b/mods/saturn/items.lua
@@ -128,7 +128,7 @@ register_wearable_item("saturn:overkiller_hull",{
 	radar_slots = 1,
 	forcefield_generator_slots = 1,
 	special_equipment_slots = 4,
-	hold_slots = 36,
+	hold_slots = 48,
 	is_market_item = true,
 	player_visual = {
 		mesh = "saturn_overkiller_ship.b3d",

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -113,7 +113,7 @@ end
 
 local get_market_formspec = function(player, market_name, ss_index)
 	local player_name = player:get_player_name()
-	local default_formspec = "size[15,9.6]"..
+	local default_formspec =
 	"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[player_name]['money']).." Cr.]"..
 	"list[detached:space_station"..ss_index..";"..market_name..";0,0;8,4;]"..
 	"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
@@ -134,17 +134,17 @@ end
 
 saturn.get_space_station_formspec = function(player, tab, ss_index)
 	local name = player:get_player_name()
+	local size = "size[15,9.6]"
 	local default_formspec = "tabheader[0,0;tabs;Equipment market,Ore market,Microfactory market,Intelligence info,Post office,Hangar and ship;"..tab..";true;false]"..
 		saturn.default_slot_color
 	if tab == 1 then
-		default_formspec = get_market_formspec(player, "market", ss_index) .. default_formspec
+		default_formspec = size .. get_market_formspec(player, "market", ss_index) .. default_formspec
 	elseif tab == 2 then
-		default_formspec = get_market_formspec(player, "ore_market", ss_index) .. default_formspec
+		default_formspec = size .. get_market_formspec(player, "ore_market", ss_index) .. default_formspec
 	elseif tab == 3 then
-		default_formspec = get_market_formspec(player, "microfactory_market", ss_index) .. default_formspec
+		default_formspec = size .. get_market_formspec(player, "microfactory_market", ss_index) .. default_formspec
 	elseif tab == 4 then
-		default_formspec = "size[15,9.6]"..
-		default_formspec..
+		default_formspec = size .. default_formspec..
 		"label[0,0;Amount of enemy ships near saturn:]"..		
 		"label[5,0;"..#saturn.virtual_enemy.."]"
 		local row = -0.3
@@ -170,8 +170,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 			"label[5,"..row..";("..ss_x..","..ss_y..","..ss_z..")]"
 		end
 	elseif tab == 5 then
-		default_formspec = "size[15,9.6]"..
-		default_formspec..
+		default_formspec = size .. default_formspec..
 		"list[detached:space_station"..ss_index..";post_office;0,0;1,4;]"..
 		"label[0,4.0;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
 		"label[4,4.0;".."Current time: "..saturn.date_to_string(minetest.get_gametime()).." (hh:mm:ss)]"..
@@ -209,8 +208,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 		end
 
 	else
-		default_formspec = "size[15,9.6]"..
-		default_formspec..
+		default_formspec = size .. default_formspec..
 		"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
 		saturn.get_ship_equipment_formspec(player)..
 		"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -114,10 +114,7 @@ end
 local get_market_formspec = function(player, market_name, ss_index)
 	local player_name = player:get_player_name()
 	local default_formspec =
-	"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[player_name]['money']).." Cr.]"..
 	"list[detached:space_station"..ss_index..";"..market_name..";0,0;8,4;]"..
-	"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
-	"list[detached:space_station"..ss_index..";buying_up_spot;7,4.5;1,1;]"..
 	"label[0,4.1;"..minetest.formspec_escape("Hangar: ").."]"..
 	"list[current_player;hangar"..ss_index..";0,4.5;6,1;]"..
 	"button[0,6;8,1;repair;Repair all player equipment. Price: "..string.format ('%4.0f',saturn.repair_player_inventory_and_get_price(player, false)).." Cr.]"
@@ -135,14 +132,18 @@ end
 saturn.get_space_station_formspec = function(player, tab, ss_index)
 	local name = player:get_player_name()
 	local size = "size[15,9.6]"
+	local money = "label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"
+	local buyout =
+	"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
+	"list[detached:space_station"..ss_index..";buying_up_spot;7,4.5;1,1;]"
 	local default_formspec = "tabheader[0,0;tabs;Equipment market,Ore market,Microfactory market,Intelligence info,Post office,Hangar and ship;"..tab..";true;false]"..
 		saturn.default_slot_color
 	if tab == 1 then
-		default_formspec = size .. get_market_formspec(player, "market", ss_index) .. default_formspec
+		default_formspec = size .. money .. buyout .. get_market_formspec(player, "market", ss_index) .. default_formspec
 	elseif tab == 2 then
-		default_formspec = size .. get_market_formspec(player, "ore_market", ss_index) .. default_formspec
+		default_formspec = size .. money .. buyout .. get_market_formspec(player, "ore_market", ss_index) .. default_formspec
 	elseif tab == 3 then
-		default_formspec = size .. get_market_formspec(player, "microfactory_market", ss_index) .. default_formspec
+		default_formspec = size .. money .. buyout .. get_market_formspec(player, "microfactory_market", ss_index) .. default_formspec
 	elseif tab == 4 then
 		default_formspec = size .. default_formspec..
 		"label[0,0;Amount of enemy ships near saturn:]"..		
@@ -172,7 +173,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 	elseif tab == 5 then
 		default_formspec = size .. default_formspec..
 		"list[detached:space_station"..ss_index..";post_office;0,0;1,4;]"..
-		"label[0,4.0;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
+		money ..
 		"label[4,4.0;".."Current time: "..saturn.date_to_string(minetest.get_gametime()).." (hh:mm:ss)]"..
 		"label[0,4.3;By taking any of those packages you accept terms and conditions of delivery.]"..
 		"label[0,4.6;Your postman rating: "..(saturn.players_info[name]['postman_rating']).."]"..
@@ -209,11 +210,10 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 
 	else
 		default_formspec = size .. default_formspec..
-		"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
+		money ..
 		saturn.get_ship_equipment_formspec(player)..
-		"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
+		buyout..
 		"list[current_player;hangar"..ss_index..";0,4.5;6,1;]"..
-		"list[detached:space_station"..ss_index..";buying_up_spot;7,4.5;1,1;]"..
 		saturn.get_main_inventory_formspec(player,5.75)
 		for ix = 1, 6 do
 			default_formspec = default_formspec.."image_button["..(ix-0.19)..",4.5;0.3,0.4;saturn_info_button_icon.png;item_info_player+"..name.."+hangar"..ss_index.."+"..ix..";]"

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -113,7 +113,7 @@ end
 
 local get_market_formspec = function(player, market_name, ss_index)
 	local player_name = player:get_player_name()
-	local default_formspec = "size[9,7]"..
+	local default_formspec = "size[15,9.6]"..
 	"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[player_name]['money']).." Cr.]"..
 	"list[detached:space_station"..ss_index..";"..market_name..";0,0;8,4;]"..
 	"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
@@ -143,7 +143,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 	elseif tab == 3 then
 		default_formspec = get_market_formspec(player, "microfactory_market", ss_index) .. default_formspec
 	elseif tab == 4 then
-		default_formspec = "size[9,4.2]"..
+		default_formspec = "size[15,9.6]"..
 		default_formspec..
 		"label[0,0;Amount of enemy ships near saturn:]"..		
 		"label[5,0;"..#saturn.virtual_enemy.."]"
@@ -170,11 +170,11 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 			"label[5,"..row..";("..ss_x..","..ss_y..","..ss_z..")]"
 		end
 	elseif tab == 5 then
-		default_formspec = "size[12,8.6]"..
+		default_formspec = "size[15,9.6]"..
 		default_formspec..
 		"list[detached:space_station"..ss_index..";post_office;0,0;1,4;]"..
 		"label[0,4.0;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
-		"label[2,4.0;".."Current time: "..saturn.date_to_string(minetest.get_gametime()).." (hh:mm:ss)]"..
+		"label[4,4.0;".."Current time: "..saturn.date_to_string(minetest.get_gametime()).." (hh:mm:ss)]"..
 		"label[0,4.3;By taking any of those packages you accept terms and conditions of delivery.]"..
 		"label[0,4.6;Your postman rating: "..(saturn.players_info[name]['postman_rating']).."]"..
 		saturn.get_main_inventory_formspec(player,5.75)
@@ -209,7 +209,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 		end
 
 	else
-		default_formspec = "size[12,8.6]"..
+		default_formspec = "size[15,9.6]"..
 		default_formspec..
 		"label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"..
 		saturn.get_ship_equipment_formspec(player)..

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -132,10 +132,10 @@ end
 saturn.get_space_station_formspec = function(player, tab, ss_index)
 	local name = player:get_player_name()
 	local size = "size[15,9.6]"
-	local money = "label[0,3.9;".."Money: "..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"
+	local money = "label[12,4.5;".."Money:\n"..string.format ('%4.0f',saturn.players_info[name]['money']).." Cr.]"
 	local buyout =
-	"label[6.8,4.1;Buyout spot:]".."image[7,4.5;1,1;saturn_money.png]"..
-	"list[detached:space_station"..ss_index..";buying_up_spot;7,4.5;1,1;]"
+	"label[12,5.45;Buyout spot:]".."image[12,5.85;1,1;saturn_money.png]"..
+	"list[detached:space_station"..ss_index..";buying_up_spot;12,5.85;1,1;]"
 	local default_formspec = "tabheader[0,0;tabs;Equipment market,Ore market,Microfactory market,Intelligence info,Post office,Hangar and ship;"..tab..";true;false]"..
 		saturn.default_slot_color
 	if tab == 1 then
@@ -177,7 +177,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 		"label[4,4.0;".."Current time: "..saturn.date_to_string(minetest.get_gametime()).." (hh:mm:ss)]"..
 		"label[0,4.3;By taking any of those packages you accept terms and conditions of delivery.]"..
 		"label[0,4.6;Your postman rating: "..(saturn.players_info[name]['postman_rating']).."]"..
-		saturn.get_main_inventory_formspec(player,5.75)
+		saturn.get_main_inventory_formspec(player,5.85)
 		local delivery_reward = saturn.deliver_package_and_get_reward(ss_index, player, false)
 		if delivery_reward > 0 then
 			default_formspec = default_formspec..
@@ -214,7 +214,7 @@ saturn.get_space_station_formspec = function(player, tab, ss_index)
 		saturn.get_ship_equipment_formspec(player)..
 		buyout..
 		"list[current_player;hangar"..ss_index..";0,4.5;6,1;]"..
-		saturn.get_main_inventory_formspec(player,5.75)
+		saturn.get_main_inventory_formspec(player,5.85)
 		for ix = 1, 6 do
 			default_formspec = default_formspec.."image_button["..(ix-0.19)..",4.5;0.3,0.4;saturn_info_button_icon.png;item_info_player+"..name.."+hangar"..ss_index.."+"..ix..";]"
 		end


### PR DESCRIPTION
The various station form tabs have varying sizes. The most
glaring problem with that is that whenever you click on a
tab, the tabs themselves jump around annoyingly.

The second problem with the tab sizes is that the forms of
most tabs are too small to fit all the tabs nicely so to
access the "Post Office" or "Hangar And Ship" you must scroll
to these first and then when you go out of them, the tabs
jump back to show the "Equipment market" and you must scroll
again when you want the "Hangar"/"Post Office" ...

Additional size problem is that some of the tabs are way too
small for the content they want to contain, especially the
"Post Office" tab where the "Destination Address" overlaps
with "Due Time" (or whatever that field is named, I can't
read the name at all, only the end of the field gives me a
clue that the field is supposed to contain the package
delivery due time.

The third problem with the sizes is that I want much bigger
markets, more stuff (especially in the Hangar) and a bigger
cargo space for the most expensive hull (and a smaller one
in the most basic form of hull).

This change fixes the "tabs jumping around" and "not all
tabs visible" problems while also adding more space space
for the other stuff I want by making the forms so big they
fill the entire screen (almost). However the form still fits
comfortably the default screen size of Minetest.