### PR TITLE
Post office update fix

### DIFF
--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -452,6 +452,25 @@ minetest.register_node("saturn:space_station_yellow_black_stripes", {
 	groups = {space_station = 1},
 })
 
+local function update_post_office(player)
+    local restart = true
+    if player:get_attach() then
+	local ship_lua = player:get_attach():get_luaentity()
+	local tab = ship_lua['current_gui_tab']
+	local i = ship_lua['last_ss']
+	local opened = ship_lua['is_node_gui_opened']
+	if opened then
+	    if tab == 5 then
+		    minetest.show_formspec(player:get_player_name(), "saturn:space_station", saturn.get_space_station_formspec(player, tab, i))
+	    end
+	else
+		restart = false
+	end
+    end
+    if restart then
+	minetest.after(0.1, update_post_office, player)
+    end
+end
 
 minetest.register_node("saturn:space_station_hatch", {
 	description = "Space station hatch",
@@ -464,10 +483,12 @@ minetest.register_node("saturn:space_station_hatch", {
 			local ship_lua = player:get_attach():get_luaentity()
 			ship_lua['current_gui_tab']=1
 			ship_lua['last_ss']=ss.index
+			ship_lua['is_node_gui_opened']=true
 			minetest.show_formspec(
 				player:get_player_name(),
 				"saturn:space_station",
 				saturn.get_space_station_formspec(player, 1, _indx))
+			minetest.after(0.1, update_post_office, player)
 		    end
 		    return
 		end

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -461,13 +461,13 @@ minetest.register_node("saturn:space_station_hatch", {
 	    for _indx,ss in ipairs(saturn.human_space_station) do
 		if saturn.is_inside_aabb(pos,ss.minp,ss.maxp) then
 		    if player:get_attach() then
+			local ship_lua = player:get_attach():get_luaentity()
+			ship_lua['current_gui_tab']=1
+			ship_lua['last_ss']=ss.index
 			minetest.show_formspec(
 				player:get_player_name(),
 				"saturn:space_station",
 				saturn.get_space_station_formspec(player, 1, _indx))
-			local ship_lua = player:get_attach():get_luaentity()
-			ship_lua['current_gui_tab']=1
-			ship_lua['last_ss']=ss.index
 		    end
 		    return
 		end


### PR DESCRIPTION
Well, maybe I found a reason why this minigame ceased to be compatible with the bleeding edge minetest. While fixing this nasty bug with the content of the post office form slowly drifting from the actual state of the post office I found a piece of bad coding when a piece of code first displayed a form (well, it was the station form to be exact) and only after the fact it proceeded to initialize the metadata that the various handlers of the form needed to handle the various items in the form (e.g. the buyout or even the aforementioned post office). If the other code harbors similar bugs, I can imagine how it can happen that the minigame works now but fails to work with a future version of minetest. This particular one got fixed by the first commit.

The post office update bug (fixed in the second commit) is also a quite nasty one and can bite the player badly when he spends quite a lot of time staring at the packages in the post office and making a decision about which one he is going to take. See the commit message of the second commit for all of the gory details.