### PR TITLE
Fix crash on overkiller hull downgrade

### DIFF
--- a/mods/saturn/player.lua
+++ b/mods/saturn/player.lua
@@ -2,9 +2,12 @@ local function throw_away_unfitted_items_from_hold(player_inv, slots_max)
     if player_inv:get_size("hold") > slots_max then
 	for listpos,stack in pairs(player_inv:get_list("hold")) do
 	    if listpos > slots_max and stack ~= nil then
-		player_inv:remove_item(list_name, stack)
-		if player:get_attach() then
+		local count = stack:get_count()
+		if count > 0 then
+		    player_inv:remove_item(list_name, stack)
+		    if player:get_attach() then
 			saturn.throw_item(stack, player:get_attach(), player:getpos())
+		    end
 		end
 	    end
 	end
@@ -16,8 +19,11 @@ local function remove_unfitted_items_to_hold(player_inv, list_name, slots_max)
     if player_inv:get_size(list_name) > slots_max then
 	for listpos,stack in pairs(player_inv:get_list(list_name)) do
 	    if listpos > slots_max and stack ~= nil then
-		player_inv:remove_item(list_name, stack)
-		player_inv:add_item("hold", stack)
+		local count = stack:get_count()
+		if count > 0 then
+		    player_inv:remove_item(list_name, stack)
+		    player_inv:add_item("hold", stack)
+		end
 	    end
 	end
     end


### PR DESCRIPTION
Ok, another reason to believe why you came to conclusion that this subgame is no longer compatible with the latest minetest builds. When I added the 12 extra slots of inventory space to the overkiller hull, I uncovered a bug that caused the game to crash when you tried to downgrade the overkiller to some lesser hull. It turns out the problem is that the code that retrofits the cargo of the overkiller to the smaller hull blindly assumes that a list position for an empty inventory stack will hold a nil while now it holds an empty stack.