### PR TITLE
Simplify volume handling

### DIFF
--- a/mods/saturn/global_functions_and_variables.lua
+++ b/mods/saturn/global_functions_and_variables.lua
@@ -162,24 +162,30 @@ saturn.get_item_weight = function(list_name, item_stack)
 	return value
 end
 
-saturn.get_item_volume = function(list_name, item_stack)
+saturn.get_item_volume_core = function(item_stack)
 	local item_name = item_stack:get_name()
 	local value = 0.01
-	if list_name == "ship_hull" or string.find(list_name,"^hangar") then
-		value = 0
-	else
-		local stats = minetest.registered_items[item_name]
-		if stats ~= nil then
-			if stats['volume'] then
-				value = stats['volume']
-				local metadata = minetest.deserialize(item_stack:get_metadata())
-				if metadata then
-					if metadata['volume'] then
-						value = value + metadata['volume']
-					end
+	local stats = minetest.registered_items[item_name]
+	if stats ~= nil then
+		if stats['volume'] then
+			value = stats['volume']
+			local metadata = minetest.deserialize(item_stack:get_metadata())
+			if metadata then
+				if metadata['volume'] then
+					value = value + metadata['volume']
 				end
 			end
 		end
+	end
+	return value
+end
+
+saturn.get_item_volume = function(list_name, item_stack)
+	local value
+	if list_name == "ship_hull" or string.find(list_name,"^hangar") then
+		value = 0
+	else
+		value = saturn.get_item_volume_core(item_stack)
 	end
 	return value
 end

--- a/mods/saturn/items.lua
+++ b/mods/saturn/items.lua
@@ -58,7 +58,6 @@ register_wearable_item("saturn:basic_ship_hull",{
     		},
 	weight = 40000,
 	volume = 400,
-	free_space = 100,
 	price = 300,
 	max_wear = 100, -- out of 65535
 	weapon_slots = 1,
@@ -88,7 +87,6 @@ register_wearable_item("saturn:basic_ship_hull_me",{
     		},
 	weight = 60000,
 	volume = 800,
-	free_space = 200,
 	price = 8000,
 	max_wear = 400, -- out of 65535
 	weapon_slots = 3,
@@ -118,7 +116,6 @@ register_wearable_item("saturn:overkiller_hull",{
     		},
 	weight = 1200000,
 	volume = 8000,
-	free_space = 2000,
 	price = 2000000,
 	max_wear = 65535, -- out of 65535
 	weapon_slots = 8,
@@ -148,7 +145,6 @@ register_wearable_item("saturn:escape_pod",{
     		},
 	weight = 1000,
 	volume = 0,
-	free_space = 0,
 	price = 0,
 	max_wear = 65535, -- out of 65535
 	weapon_slots = 0,

--- a/mods/saturn/items.lua
+++ b/mods/saturn/items.lua
@@ -57,7 +57,7 @@ register_wearable_item("saturn:basic_ship_hull",{
 		        groupcaps = {},
     		},
 	weight = 40000,
-	volume = 400,
+	volume = 100,
 	price = 300,
 	max_wear = 100, -- out of 65535
 	weapon_slots = 1,
@@ -86,7 +86,7 @@ register_wearable_item("saturn:basic_ship_hull_me",{
 		        groupcaps = {},
     		},
 	weight = 60000,
-	volume = 800,
+	volume = 100,
 	price = 8000,
 	max_wear = 400, -- out of 65535
 	weapon_slots = 3,
@@ -115,7 +115,7 @@ register_wearable_item("saturn:overkiller_hull",{
 		        groupcaps = {},
     		},
 	weight = 1200000,
-	volume = 8000,
+	volume = 100,
 	price = 2000000,
 	max_wear = 65535, -- out of 65535
 	weapon_slots = 8,
@@ -144,7 +144,7 @@ register_wearable_item("saturn:escape_pod",{
 		        groupcaps = {},
     		},
 	weight = 1000,
-	volume = 0,
+	volume = 100,
 	price = 0,
 	max_wear = 65535, -- out of 65535
 	weapon_slots = 0,
@@ -986,9 +986,9 @@ register_craft_item("saturn:enemy_hull_shard_d",{
 register_craft_item("saturn:gauss_solid_ironnickel_bullets",{
 		description = "Gauss solid ironnickel bullets",
 		inventory_image = "saturn_gauss_solid_ironnickel_bullets.png",
-		stack_max = 999,
+		stack_max = 10000,
 	weight = 10,
-	volume = 0.0001,
+	volume = 0.01,
 	price = 1,
 	is_market_item = true,
 	gauss_ammo = true,
@@ -998,9 +998,9 @@ register_craft_item("saturn:gauss_solid_ironnickel_bullets",{
 register_craft_item("saturn:gauss_mo_permalloy_with_depleted_uranium_core_bullets",{
 		description = "Gauss Mo-permalloy with depleted uranium core bullets",
 		inventory_image = "saturn_gauss_mo_permalloy_with_depleted_uranium_core_bullets.png",
-		stack_max = 999,
+		stack_max = 10000,
 	weight = 11,
-	volume = 0.0001,
+	volume = 0.01,
 	price = 2.25,
 	is_market_item = true,
 	gauss_ammo = true,
@@ -1010,9 +1010,9 @@ register_craft_item("saturn:gauss_mo_permalloy_with_depleted_uranium_core_bullet
 register_craft_item("saturn:railgun_aluminium_uhmwpe_ammo",{
 		description = "Railgun UHMWPE bullets with aluminium conductive part",
 		inventory_image = "saturn_railgun_aluminium_uhmwpe_ammo.png",
-		stack_max = 999,
+		stack_max = 10000,
 	weight = 4,
-	volume = 0.0001,
+	volume = 0.01,
 	price = 1,
 	is_market_item = true,
 	railgun_ammo = true,
@@ -1035,7 +1035,7 @@ register_craft_item("saturn:mail_package",{
 register_craft_item("saturn:clean_water",{
 		description = "Clean water",
 		inventory_image = "saturn_cells.png^[verticalframe:64:1",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.2,
@@ -1045,7 +1045,7 @@ register_craft_item("saturn:clean_water",{
 register_craft_item("saturn:heavy_water",{
 		description = "Heavy water",
 		inventory_image = "saturn_cells.png^[verticalframe:64:2",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1,
@@ -1055,7 +1055,7 @@ register_craft_item("saturn:heavy_water",{
 register_craft_item("saturn:silicate_mix",{
 		description = "Silicate mix",
 		inventory_image = "saturn_cells.png^[verticalframe:64:3",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.1,
@@ -1065,7 +1065,7 @@ register_craft_item("saturn:silicate_mix",{
 register_craft_item("saturn:ammonia",{
 		description = "Ammonia",
 		inventory_image = "saturn_cells.png^[verticalframe:64:4",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.5,
@@ -1075,7 +1075,7 @@ register_craft_item("saturn:ammonia",{
 register_craft_item("saturn:acetic_acid",{
 		description = "Acetic acid",
 		inventory_image = "saturn_cells.png^[verticalframe:64:5",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.1,
@@ -1085,7 +1085,7 @@ register_craft_item("saturn:acetic_acid",{
 register_craft_item("saturn:formic_acid",{
 		description = "Formic acid",
 		inventory_image = "saturn_cells.png^[verticalframe:64:6",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.1,
@@ -1095,7 +1095,7 @@ register_craft_item("saturn:formic_acid",{
 register_craft_item("saturn:amorphous_carbon",{
 		description = "Amorphous carbon",
 		inventory_image = "saturn_cells.png^[verticalframe:64:7",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.1,
@@ -1105,7 +1105,7 @@ register_craft_item("saturn:amorphous_carbon",{
 register_craft_item("saturn:carbon_dioxide",{
 		description = "Carbon dioxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:8",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.5,
@@ -1115,7 +1115,7 @@ register_craft_item("saturn:carbon_dioxide",{
 register_craft_item("saturn:phosphine",{
 		description = "Phosphine",
 		inventory_image = "saturn_cells.png^[verticalframe:64:9",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.5,
@@ -1125,7 +1125,7 @@ register_craft_item("saturn:phosphine",{
 register_craft_item("saturn:orthophosphoric_acid",{
 		description = "Orthophosphoric acid",
 		inventory_image = "saturn_cells.png^[verticalframe:64:10",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 3,
@@ -1135,7 +1135,7 @@ register_craft_item("saturn:orthophosphoric_acid",{
 register_craft_item("saturn:ammonia_nitrate",{
 		description = "Ammonia nitrate",
 		inventory_image = "saturn_cells.png^[verticalframe:64:11",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1,
@@ -1145,7 +1145,7 @@ register_craft_item("saturn:ammonia_nitrate",{
 register_craft_item("saturn:diammonium_phosphate",{
 		description = "Diammonium phosphate",
 		inventory_image = "saturn_cells.png^[verticalframe:64:12",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1,
@@ -1155,7 +1155,7 @@ register_craft_item("saturn:diammonium_phosphate",{
 register_craft_item("saturn:oxygen",{
 		description = "Oxygen",
 		inventory_image = "saturn_cells.png^[verticalframe:64:13",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.5,
@@ -1165,7 +1165,7 @@ register_craft_item("saturn:oxygen",{
 register_craft_item("saturn:nitric_acid",{
 		description = "Nitric acid",
 		inventory_image = "saturn_cells.png^[verticalframe:64:14",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.5,
@@ -1175,7 +1175,7 @@ register_craft_item("saturn:nitric_acid",{
 register_craft_item("saturn:hydrogen_sulphide",{
 		description = "Hydrogen sulphide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:15",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.5,
@@ -1185,7 +1185,7 @@ register_craft_item("saturn:hydrogen_sulphide",{
 register_craft_item("saturn:sulphur",{
 		description = "Sulphur",
 		inventory_image = "saturn_cells.png^[verticalframe:64:16",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.2,
@@ -1195,7 +1195,7 @@ register_craft_item("saturn:sulphur",{
 register_craft_item("saturn:sulphide_salts_mix",{
 		description = "Sulphide salts mix",
 		inventory_image = "saturn_cells.png^[verticalframe:64:17",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 0.2,
@@ -1205,7 +1205,7 @@ register_craft_item("saturn:sulphide_salts_mix",{
 register_craft_item("saturn:silicon_dioxide",{
 		description = "Silicon_dioxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:18",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.5,
@@ -1215,7 +1215,7 @@ register_craft_item("saturn:silicon_dioxide",{
 register_craft_item("saturn:potassium_oxide",{
 		description = "Potassium oxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:19",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 10,
@@ -1225,7 +1225,7 @@ register_craft_item("saturn:potassium_oxide",{
 register_craft_item("saturn:calcium_oxide",{
 		description = "Calcium oxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:20",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 10,
@@ -1235,7 +1235,7 @@ register_craft_item("saturn:calcium_oxide",{
 register_craft_item("saturn:magnesium_oxide",{
 		description = "Magnesium oxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:21",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 10,
@@ -1245,7 +1245,7 @@ register_craft_item("saturn:magnesium_oxide",{
 register_craft_item("saturn:sodium_oxide",{
 		description = "Sodium oxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:22",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 10,
@@ -1255,7 +1255,7 @@ register_craft_item("saturn:sodium_oxide",{
 register_craft_item("saturn:alkali_solution",{
 		description = "Alkali solution",
 		inventory_image = "saturn_cells.png^[verticalframe:64:23",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.5,
@@ -1265,7 +1265,7 @@ register_craft_item("saturn:alkali_solution",{
 register_craft_item("saturn:metal_oxides_sludge",{
 		description = "Metal oxides sludge",
 		inventory_image = "saturn_cells.png^[verticalframe:64:24",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.5,
@@ -1275,7 +1275,7 @@ register_craft_item("saturn:metal_oxides_sludge",{
 register_craft_item("saturn:sodiumless_lithiumless_alkali_solution",{
 		description = "Sodiumless lithiumless alkali solution",
 		inventory_image = "saturn_cells.png^[verticalframe:64:25",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 6,
@@ -1285,7 +1285,7 @@ register_craft_item("saturn:sodiumless_lithiumless_alkali_solution",{
 register_craft_item("saturn:sulphuric_acid",{
 		description = "Sulphuric acid",
 		inventory_image = "saturn_cells.png^[verticalframe:64:26",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 1.1,
@@ -1295,7 +1295,7 @@ register_craft_item("saturn:sulphuric_acid",{
 register_craft_item("saturn:sodium_hydroxide",{
 		description = "Sodium hydroxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:27",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 6,
@@ -1305,7 +1305,7 @@ register_craft_item("saturn:sodium_hydroxide",{
 register_craft_item("saturn:lithium_hydroxide",{
 		description = "lithium hydroxide",
 		inventory_image = "saturn_cells.png^[verticalframe:64:28",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 6,
@@ -1315,7 +1315,7 @@ register_craft_item("saturn:lithium_hydroxide",{
 register_craft_item("saturn:complex_fertilizer",{
 		description = "Complex fertilizer pellets for hydroponic farms",
 		inventory_image = "saturn_complex_fertilizer.png",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 4.5,
@@ -1325,7 +1325,7 @@ register_craft_item("saturn:complex_fertilizer",{
 register_craft_item("saturn:fresh_fruits_and_vegetables",{
 		description = "Fresh fruits and vegetables",
 		inventory_image = "saturn_fresh_fruits_and_vegetables.png",
-		stack_max = 9999,
+		stack_max = 10000,
 	weight = 10,
 	volume = 0.01,
 	price = 8,

--- a/mods/saturn/missing_api_gag.lua
+++ b/mods/saturn/missing_api_gag.lua
@@ -7,7 +7,6 @@ if not minetest.register_on_player_inventory_add_item then
     saturn.players_weights_total = {}    
 
     calculate_carried_weight = saturn.calculate_carried_weight
-    calculate_carried_volume = saturn.calculate_carried_volume
     refresh_ship_equipment = saturn.refresh_ship_equipment
     apply_cargo = saturn.apply_cargo
 
@@ -42,7 +41,7 @@ if not minetest.register_on_player_inventory_add_item then
 		    weight = weight + listweight
 		end
 		if saturn.players_weights_total[name] ~= weight then
-		    	apply_cargo(player,weight,calculate_carried_volume(inv))
+		    	apply_cargo(player,weight)
 			saturn.players_weights_total[name] = weight
 		end
 	    end

--- a/mods/saturn/nodes.lua
+++ b/mods/saturn/nodes.lua
@@ -59,6 +59,7 @@ register_node_with_stats("saturn:water_ice", {
 	volume = 1, --m3
 	price = 1.43,
 	toughness = 8,
+	stack_max = 100,
 })
 
 table.insert(saturn.ore_market_items, "saturn:water_ice")
@@ -74,6 +75,7 @@ register_node_with_stats("saturn:bauxite", {
 	noise_offset = -1.1,
 	is_ore = true,
 	toughness = 8,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:ironnickel", {
@@ -87,6 +89,7 @@ register_node_with_stats("saturn:ironnickel", {
 	noise_offset = -1.1,
 	is_ore = true,
 	toughness = 80,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:gold", {
@@ -100,6 +103,7 @@ register_node_with_stats("saturn:gold", {
 	noise_offset = -1.5,
 	is_ore = true,
 	toughness = 80,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:pitchblende", {
@@ -113,6 +117,7 @@ register_node_with_stats("saturn:pitchblende", {
 	noise_offset = -1.5,
 	is_ore = true,
 	toughness = 80,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:nitrile_ice", { -- Give ammonia and various carboxylic acids with water
@@ -126,6 +131,7 @@ register_node_with_stats("saturn:nitrile_ice", { -- Give ammonia and various car
 	noise_offset = -1.1,
 	is_ore = true,
 	toughness = 8,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:carbon_oxides_ice", { -- Give some water, carbon dioxide and some amorphic carbon
@@ -139,6 +145,7 @@ register_node_with_stats("saturn:carbon_oxides_ice", { -- Give some water, carbo
 	noise_offset = -1.1,
 	is_ore = true,
 	toughness = 8,
+	stack_max = 100,
 })
 
 register_node_with_stats("saturn:hydrogen_sulphide_ice", { -- Give some hydrogen sulphide and some sulphur
@@ -152,6 +159,7 @@ register_node_with_stats("saturn:hydrogen_sulphide_ice", { -- Give some hydrogen
 	noise_offset = -1.1,
 	is_ore = true,
 	toughness = 8,
+	stack_max = 100,
 })
 
 
@@ -166,4 +174,5 @@ register_node_with_stats("saturn:phosphine_clathrate", { -- Give phosphine, orth
 	noise_offset = -1.2,
 	is_ore = true,
 	toughness = 8,
+	stack_max = 100,
 })

--- a/mods/saturn/player.lua
+++ b/mods/saturn/player.lua
@@ -82,29 +82,13 @@ local function calculate_carried_weight(inv)
 	return weight
 end
 
-local function calculate_carried_volume(inv)
-	local volume = 0
-	for list_name,list in pairs(inv:get_lists()) do
-		if list_name ~= "ship_hull" and list_name ~= "craft" and list_name ~= "craftresult" then
-			for listpos,stack in pairs(list) do
-				if stack ~= nil then
-					volume = volume + saturn.get_item_volume(list_name, stack) * stack:get_count()
-				end
-			end
-		end
-	end
-	return volume
-end
-
-local function apply_cargo(player, new_carried_weight, new_carried_volume)
+local function apply_cargo(player, new_carried_weight)
 	local ship_lua = player:get_attach():get_luaentity()
 	ship_lua['weight']=new_carried_weight
-	ship_lua['volume']=new_carried_volume
 	player:set_inventory_formspec(saturn.get_player_inventory_formspec(player,ship_lua['current_gui_tab']))
 end
 
 saturn.calculate_carried_weight = calculate_carried_weight
-saturn.calculate_carried_volume = calculate_carried_volume
 saturn.apply_cargo = apply_cargo
 
 local function apply_modificator_to_ship_safe(ship_lua, modificator_key, value)
@@ -559,7 +543,7 @@ local attach_player_to_ship = function(player, ship_lua)
 	    define_player_inventory_slots(player, start_hull)
 	    give_initial_stuff(player, start_hull)
 	end
-	apply_cargo(player,calculate_carried_weight(player:get_inventory()),calculate_carried_volume(player:get_inventory()))
+	apply_cargo(player,calculate_carried_weight(player:get_inventory()))
 	refresh_ship_equipment(player, "any")
 	saturn.refresh_health_hud(player)
 end
@@ -608,7 +592,6 @@ local spaceship = {
 	one_second_timer = 0.0,
 	hit_effect_timer = 0,
 	weight = 65535,
-	volume = 0,
 	traction = 0,
 	droid_efficiency = 0,
 	radar_range = 0,
@@ -994,10 +977,9 @@ if minetest.register_on_player_inventory_add_item then
 	    local name = player:get_player_name()
 	    local ship_lua = player:get_attach():get_luaentity()
 	    local new_carried_weight = ship_lua['weight'] + saturn.get_item_weight(list_to, stack) * stack:get_count()
-	    local new_carried_volume = ship_lua['volume'] + saturn.get_item_volume(list_to, stack) * stack:get_count()
 	    local hull = player:get_inventory():get_stack("ship_hull", 1)
 	    refresh_ship_equipment(player, list_to)
-	    apply_cargo(player,new_carried_weight, new_carried_volume)
+	    apply_cargo(player,new_carried_weight)
     	end
     end)
 
@@ -1007,9 +989,8 @@ if minetest.register_on_player_inventory_add_item then
 		local name = player:get_player_name()
 		local ship_lua = player:get_attach():get_luaentity()
 		local new_carried_weight = ship_lua['weight'] + saturn.get_item_weight(list_to, new_item) * new_item:get_count() - saturn.get_item_weight(list_to, old_item) * old_item:get_count()
-		local new_carried_volume = ship_lua['volume'] + saturn.get_item_volume(list_to, new_item) * new_item:get_count() - saturn.get_item_volume(list_to, old_item) * old_item:get_count()
 		refresh_ship_equipment(player, list_to)
-		apply_cargo(player,new_carried_weight, new_carried_volume)
+		apply_cargo(player,new_carried_weight)
 	    end
     	end
     end)
@@ -1019,9 +1000,8 @@ if minetest.register_on_player_inventory_add_item then
 	    local name = player:get_player_name()
 	    local ship_lua = player:get_attach():get_luaentity()
 	    local new_carried_weight = ship_lua['weight'] - saturn.get_item_weight(list_from, stack) * stack:get_count()
-	    local new_carried_volume = ship_lua['volume'] - saturn.get_item_volume(list_from, stack) * stack:get_count()
 	    refresh_ship_equipment(player, list_from)
-	    apply_cargo(player,new_carried_weight, new_carried_volume)
+	    apply_cargo(player,new_carried_weight)
 	end
     end)
 

--- a/mods/saturn/player.lua
+++ b/mods/saturn/player.lua
@@ -150,14 +150,12 @@ local function refresh_hull(player)
 	local stats = saturn.get_item_stats(stack_name)
 		ship_lua.is_escape_pod = (stack_name == "saturn:escape_pod")
 		if stats then
-			if stats['free_space'] and 
-			stats['engine_slots'] and
+			if stats['engine_slots'] and
 			stats['power_generator_slots'] and
 			stats['droid_slots'] and
 			stats['radar_slots'] and
 			stats['forcefield_generator_slots'] and
 			stats['special_equipment_slots'] then
-				ship_lua['free_space'] = stats['free_space']
 				define_player_inventory_slots(player, stack)
 				player:set_properties(stats.player_visual)
 				local metadata = minetest.deserialize(stack:get_metadata())
@@ -611,7 +609,6 @@ local spaceship = {
 	hit_effect_timer = 0,
 	weight = 65535,
 	volume = 0,
-	free_space = 0,
 	traction = 0,
 	droid_efficiency = 0,
 	radar_range = 0,
@@ -999,14 +996,8 @@ if minetest.register_on_player_inventory_add_item then
 	    local new_carried_weight = ship_lua['weight'] + saturn.get_item_weight(list_to, stack) * stack:get_count()
 	    local new_carried_volume = ship_lua['volume'] + saturn.get_item_volume(list_to, stack) * stack:get_count()
 	    local hull = player:get_inventory():get_stack("ship_hull", 1)
-	    local hull_volume = ship_lua['free_space']
 	    refresh_ship_equipment(player, list_to)
 	    apply_cargo(player,new_carried_weight, new_carried_volume)
-	    if list_to ~= "ship_hull" and new_carried_volume > hull_volume then
-		minetest.sound_play("saturn_whoosh", {to_player = name})
-		saturn.throw_item(stack, player:get_attach(), player:getpos())
-		player:get_inventory():remove_item(list_to, stack)
-	    end
     	end
     end)
 
@@ -1016,14 +1007,9 @@ if minetest.register_on_player_inventory_add_item then
 		local name = player:get_player_name()
 		local ship_lua = player:get_attach():get_luaentity()
 		local new_carried_weight = ship_lua['weight'] + saturn.get_item_weight(list_to, new_item) * new_item:get_count() - saturn.get_item_weight(list_to, old_item) * old_item:get_count()
-		local hull_volume = ship_lua['free_space']
 		local new_carried_volume = ship_lua['volume'] + saturn.get_item_volume(list_to, new_item) * new_item:get_count() - saturn.get_item_volume(list_to, old_item) * old_item:get_count()
 		refresh_ship_equipment(player, list_to)
 		apply_cargo(player,new_carried_weight, new_carried_volume)
-		if list_to ~= "ship_hull" and new_carried_volume > hull_volume then
-			saturn.throw_item(new_item, player:get_attach(), player:getpos())
-			player:get_inventory():remove_item(list_to, new_item)
-		end
 	    end
     	end
     end)


### PR DESCRIPTION
The minetest already has some sort of "object volume handling" implemented so there is no need to duplicate that functionality in the subgame. The reuse of the "object volume handling" works by declaring one inventory slot to be able to hold 100 cubic meters of stuff and editing the max_stack and volume properties of the various items to reflect that. The incomplete code that was trying to handle the volume was removed first to prevent any conflicts it might produce with the changes of the node and item stats that bring them in line with the "object volume handling" in minetest. This is in line with the minecraft-like play the minetest engine is using as well as with the "elite" games this subgame is simulating (in "elite" you could not buy more stuff that would actually fit into the cargo hold).