### PR TITLE
Fix map becoming "stale" after player moves

### DIFF
--- a/mods/saturn/global_functions_and_variables.lua
+++ b/mods/saturn/global_functions_and_variables.lua
@@ -430,7 +430,6 @@ saturn.punch_object = function(punched, puncher, damage)
 			end
 			saturn.refresh_health_hud(punched)
 			local name = punched:get_player_name()
-			punched:set_inventory_formspec(saturn.get_player_inventory_formspec(punched,ship_lua['current_gui_tab']))
 			ship_lua.hit_effect_timer = 3.0
 			ship_lua.last_attacker = puncher
 

--- a/mods/saturn/gui.lua
+++ b/mods/saturn/gui.lua
@@ -317,6 +317,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
     if ship then
 	local ship_lua = ship:get_luaentity()
 	if fields.tabs or fields.ii_return then
+		if fields.ii_return then
+			ship_lua['info_active'] = nil
+		end
 		local tab = ship_lua['current_gui_tab']
 		if fields.tabs then
 			tab = tonumber(fields.tabs)
@@ -324,8 +327,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		ship_lua['current_gui_tab'] = tab
 		if formname == "saturn:space_station" then
 			minetest.show_formspec(player:get_player_name(), "saturn:space_station", saturn.get_space_station_formspec(player, tab, ship_lua['last_ss']))
-		else
-			player:set_inventory_formspec(get_player_inventory_formspec(player, tab))
 		end
 	elseif fields.repair then
 		saturn.repair_player_inventory_and_get_price(player, true)
@@ -352,7 +353,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			if match == 1 and parameters_list then
 				local scale = tonumber(parameters_list)
 				ship_lua['map_scale'] = scale
-				player:set_inventory_formspec(get_player_inventory_formspec(player, 3))
 			end
 		end
 		if fields.quit then
@@ -372,6 +372,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		end
 	elseif fields.quit then
 		ship_lua['is_node_gui_opened'] = false
+		ship_lua['info_active'] = nil
 	else
 		for key,v in pairs(fields) do
 			local parameters_list, match = string.gsub(key, "^item_info_", "")
@@ -392,6 +393,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				end
 				local item_stack = inventory:get_stack(inventory_list_name, inventory_slot_number)
 				if not item_stack:is_empty() then
+					ship_lua['info_active'] = true
 					if formname == "saturn:space_station" then
 						minetest.show_formspec(player:get_player_name(), "saturn:space_station", saturn.get_item_info_formspec(item_stack))
 					else


### PR DESCRIPTION
Go to the inventory screen and switch to the map. Exit the
inventory screen. Start your engines and move somewhere else.
Go back to the inventory. The map should show up but it will
still show the old location of the player. Only after
switching the tabs the map updates itself.

The problem is that the formspec becoms outdated if the form
is supposed to show the map and the player moves. To fix the
problem, the various "set_player_inventory_formspec" calls
around the code are removed and replaced with a timer
procedure that invokes the set_player_inventory_formspec
periodically 10 times per second no matter what is happening
to the player.

However care needs to be taken to not do this periodic form
updating when the info form is shown as that would make it
impossible to show the info form at all. Therefore a new
state variable is introduced which tracks whether there is
an info form open so the periodic form updater can make sure
the info form is left intact.