### PR TITLE
Fix space station form messing up inventory tab

### DIFF
--- a/mods/saturn/gui.lua
+++ b/mods/saturn/gui.lua
@@ -371,6 +371,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 		end
 	elseif fields.quit then
+		if formname == "saturn:space_station" then
+			local tab = ship_lua['last_gui_tab']
+			ship_lua['last_gui_tab'] = nil
+			ship_lua['current_gui_tab'] = tab
+		end
 		ship_lua['is_node_gui_opened'] = false
 	else
 		for key,v in pairs(fields) do

--- a/mods/saturn/space_station.lua
+++ b/mods/saturn/space_station.lua
@@ -481,6 +481,7 @@ minetest.register_node("saturn:space_station_hatch", {
 		if saturn.is_inside_aabb(pos,ss.minp,ss.maxp) then
 		    if player:get_attach() then
 			local ship_lua = player:get_attach():get_luaentity()
+			ship_lua['last_gui_tab']=ship_lua['current_gui_tab']
 			ship_lua['current_gui_tab']=1
 			ship_lua['last_ss']=ss.index
 			ship_lua['is_node_gui_opened']=true


### PR DESCRIPTION
After the user interacts with the space staton, the inventory
form forgets which tab it had selected. If the player left
the space station form while viewing one of the three
markets, the inventory form will show one of the three
inventory form tabs. If the station interaction was
terminated while one of the non-market tabs was being shown,
the inventory form will show an empty page and the player is
required to select one of the three tabs to make it work.

The problem turns out to be that the two forms use the same
ship state variable to remember which tab is selected and
the space station interaction code does not bother restoring
the value of the ship state variable to what the inventory
form had there. Adding this missing functionality fixes the
problem.