### PR TITLE
Clean up abandoned spaceships

### DIFF
--- a/mods/saturn/player.lua
+++ b/mods/saturn/player.lua
@@ -617,6 +617,9 @@ local spaceship = {
 
 function spaceship:on_step(dtime)
 	self.age = self.age + dtime
+	if not self.driver then
+		self.object:remove()
+	end
 	if self.driver and self.driver:get_look_dir() then
 		local player = self.driver
 		local name = player:get_player_name()


### PR DESCRIPTION
The world anchor and protector indicator is misplaced and shows area that is 1-2 nodes bigger than what is actually protected. Fix that and additionally remove the confusing "protector surround" indication in the middle of the area which serves no purpose here.